### PR TITLE
Add support for Seamless View

### DIFF
--- a/src/SwedbankPay/Core/Library/Methods/Card.php
+++ b/src/SwedbankPay/Core/Library/Methods/Card.php
@@ -47,6 +47,7 @@ trait Card
                 'userAgent' => $order->getHttpUserAgent(),
                 'language' => $order->getLanguage(),
                 'urls' => [
+                    'hostUrls' => $urls->getHostUrls(),
                     'completeUrl' => $urls->getCompleteUrl(),
                     'cancelUrl' => $urls->getCancelUrl(),
                     'callbackUrl' => $urls->getCallbackUrl(),

--- a/src/SwedbankPay/Core/Library/Methods/Swish.php
+++ b/src/SwedbankPay/Core/Library/Methods/Swish.php
@@ -44,6 +44,7 @@ trait Swish
                 'userAgent' => $order->getHttpUserAgent(),
                 'language' => $order->getLanguage(),
                 'urls' => [
+                    'hostUrls' => $urls->getHostUrls(),
                     'completeUrl' => $urls->getCompleteUrl(),
                     'cancelUrl' => $urls->getCancelUrl(),
                     'callbackUrl' => $urls->getCallbackUrl(),


### PR DESCRIPTION
Both the Credit Card and Swish payment instrument requires the 'hostUrls' field to support Seamless View.

The following has been copied from the credit card [docs](https://developer.swedbankpay.com/payments/card/seamless-view#step-1-create-payment):

> The array of URLs valid for embedding of Swedbank Pay Hosted Views. If not supplied, view-operation will not be available.