### PR TITLE
Updates

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,10 @@ jobs:
           PAYEE_ID: ${{ secrets.PAYEE_ID }}
           ACCESS_TOKEN_MOBILEPAY: ${{ secrets.ACCESS_TOKEN_MOBILEPAY }}
           PAYEE_ID_MOBILEPAY: ${{ secrets.PAYEE_ID_MOBILEPAY }}
-        run: composer install && ./vendor/bin/phpunit --configuration=./tests/phpunit.xml --bootstrap=./tests/bootstrap.php ./tests/ --coverage-clover=coverage.xml
+        run: |
+          sed -i -e "s/~4.0/dev-master/g" ./composer.json
+          composer install
+          ./vendor/bin/phpunit --configuration=./tests/phpunit.xml --bootstrap=./tests/bootstrap.php ./tests/ --coverage-clover=coverage.xml
 
       - name: Upload code coverage report to Codecov
         env:

--- a/src/SwedbankPay/Core/Adapter/WC_Adapter.php
+++ b/src/SwedbankPay/Core/Adapter/WC_Adapter.php
@@ -22,6 +22,8 @@ use WC_Order_Item_Fee;
  * @package SwedbankPay\Core\Adapter
  * @SuppressWarnings(PHPMD.CamelCaseClassName)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength)
+ * @SuppressWarnings(PHPMD.TooManyMethods)
  */
 // phpcs:ignore
 class WC_Adapter extends PaymentAdapter implements PaymentAdapterInterface

--- a/src/SwedbankPay/Core/Api/TransactionInterface.php
+++ b/src/SwedbankPay/Core/Api/TransactionInterface.php
@@ -36,6 +36,8 @@ interface TransactionInterface
     const STATE_PENDING = 'Pending';
     const STATE_COMPLETED = 'Completed';
     const STATE_FAILED = 'Failed';
+    const STATE_INITIALIZED = 'Initialized';
+    const STATE_AWAITING_ACTIVITY = 'AwaitingActivity';
 
     const VAT_AMOUNT = 'vatAmount';
     const PAYEE_REFERENCE = 'payeeReference';

--- a/src/SwedbankPay/Core/CoreInterface.php
+++ b/src/SwedbankPay/Core/CoreInterface.php
@@ -16,6 +16,7 @@ interface CoreInterface
     const OPERATION_PURCHASE = 'Purchase';
     const OPERATION_VERIFY = 'Verify';
     const OPERATION_RECUR = 'Recur';
+    const OPERATION_UPDATE_ORDER = 'UpdateOrder';
 
     /**
      * Can Capture.

--- a/src/SwedbankPay/Core/Library/Methods/Card.php
+++ b/src/SwedbankPay/Core/Library/Methods/Card.php
@@ -287,9 +287,8 @@ trait Card
             ->setInitiatingSystemUserAgent($this->adapter->getInitiatingSystemUserAgent())
             ->setOperation(self::OPERATION_RECUR)
             ->setIntent(
-                $this->configuration->getAutoCapture() ?
-                    self::INTENT_AUTOCAPTURE : self::INTENT_AUTHORIZATION
-                )
+                $this->configuration->getAutoCapture() ? self::INTENT_AUTOCAPTURE : self::INTENT_AUTHORIZATION
+            )
             ->setCurrency($order->getCurrency())
             ->setAmount($order->getAmountInCents())
             ->setVatAmount($order->getVatAmountInCents())

--- a/src/SwedbankPay/Core/Library/Methods/Checkout.php
+++ b/src/SwedbankPay/Core/Library/Methods/Checkout.php
@@ -7,6 +7,27 @@ use SwedbankPay\Core\Exception;
 use SwedbankPay\Core\Log\LogLevel;
 use SwedbankPay\Core\Order;
 use SwedbankPay\Core\OrderInterface;
+use SwedbankPay\Core\Api\TransactionInterface;
+
+use SwedbankPay\Api\Client\Exception as ClientException;
+use SwedbankPay\Api\Service\Paymentorder\Resource\Request\Paymentorder;
+use SwedbankPay\Api\Service\Paymentorder\Resource\Collection\OrderItemsCollection;
+use SwedbankPay\Api\Service\Paymentorder\Resource\Collection\Item\OrderItem;
+use SwedbankPay\Api\Service\Paymentorder\Resource\PaymentorderUrl;
+use SwedbankPay\Api\Service\Paymentorder\Resource\PaymentorderPayeeInfo;
+use SwedbankPay\Api\Service\Paymentorder\Resource\PaymentorderPayer;
+use SwedbankPay\Api\Service\Paymentorder\Resource\PaymentorderMetadata;
+use SwedbankPay\Api\Service\Paymentorder\Request\Purchase;
+use SwedbankPay\Api\Service\Paymentorder\Request\Verify;
+use SwedbankPay\Api\Service\Paymentorder\Request\Recur;
+use SwedbankPay\Api\Service\Paymentorder\Resource\PaymentorderObject;
+use SwedbankPay\Api\Service\Paymentorder\Resource\PaymentorderRiskIndicator;
+use SwedbankPay\Api\Service\Data\ResponseInterface as ResponseServiceInterface;
+use SwedbankPay\Api\Service\Paymentorder\Transaction\Resource\Request\Transaction;
+use SwedbankPay\Api\Service\Paymentorder\Transaction\Resource\Request\TransactionObject;
+use SwedbankPay\Api\Service\Paymentorder\Transaction\Request\TransactionCapture;
+use SwedbankPay\Api\Service\Paymentorder\Transaction\Request\TransactionCancel;
+use SwedbankPay\Api\Service\Paymentorder\Transaction\Request\TransactionReversal;
 
 trait Checkout
 {
@@ -32,69 +53,118 @@ trait Checkout
 
         $urls = $this->getPlatformUrls($orderId);
 
-        $params = [
-            'paymentorder' => [
-                'initiatingSystemUserAgent' => $this->adapter->getInitiatingSystemUserAgent(),
-                'operation' => self::OPERATION_PURCHASE,
-                'currency' => $order->getCurrency(),
-                'amount' => $order->getAmountInCents(),
-                'vatAmount' => $order->getVatAmountInCents(),
-                'description' => $order->getDescription(),
-                'userAgent' => $order->getHttpUserAgent(),
-                'language' => $order->getLanguage(),
-                'generateRecurrenceToken' => $generateRecurrenceToken,
-                'disablePaymentMenu' => false,
-                'urls' => [
-                    'hostUrls' => $urls->getHostUrls(),
-                    'completeUrl' => $urls->getCompleteUrl(),
-                    'cancelUrl' => $urls->getCancelUrl(),
-                    'callbackUrl' => $urls->getCallbackUrl(),
-                    'termsOfServiceUrl' => $urls->getTermsUrl(),
-                    'logoUrl' => $urls->getLogoUrl(),
-                    'paymentUrl' => $urls->getPaymentUrl()
-                ],
-                'payeeInfo' => $this->getPayeeInfo($orderId)->toArray(),
-                'orderItems' => $order->getItems(),
-                'metadata' => [
-                    'order_id' => $order->getOrderId()
-                ],
-                'items' => [
-                    [
-                        'creditCard' => [
-                            'rejectCreditCards' => $this->configuration->getRejectCreditCards(),
-                            'rejectDebitCards' => $this->configuration->getRejectDebitCards(),
-                            'rejectConsumerCards' => $this->configuration->getRejectConsumerCards(),
-                            'rejectCorporateCards' => $this->configuration->getRejectCorporateCards()
-                        ]
-                    ]
-                ]
-            ]
-        ];
+        $urlData = new PaymentorderUrl();
+        $urlData
+            ->setHostUrls($urls->getHostUrls())
+            ->setCompleteUrl($urls->getCompleteUrl())
+            ->setCancelUrl($urls->getCompleteUrl())
+            ->setPaymentUrl($urls->getPaymentUrl())
+            ->setCallbackUrl($urls->getCallbackUrl())
+            ->setTermsOfService($urls->getTermsUrl())
+            ->setLogoUrl($urls->getLogoUrl());
 
-        // Add payer info
-        if ($this->configuration->getUsePayerInfo()) {
-            $params['paymentorder']['payer'] = $order->getCardHolderInformation();
-        }
+        $payeeInfo = new PaymentorderPayeeInfo($this->getPayeeInfo($orderId)->toArray());
+
+        $payer = new PaymentorderPayer();
 
         // Add consumerProfileRef if exists
         if (!empty($consumerProfileRef)) {
-            if (!isset($params['paymentorder']['payer'])) {
-                $params['paymentorder']['payer'] = [];
-            }
-
-            $params['paymentorder']['payer']['consumerProfileRef'] = $consumerProfileRef;
+            $payer->setConsumerProfileRef($consumerProfileRef);
         }
 
+        // Add payer info
+        if ($this->configuration->getUsePayerInfo()) {
+            $payer->setEmail($order->getBillingEmail())
+                  ->setMsisdn($order->getBillingPhone())
+                  ->setWorkPhoneNumber($order->getBillingPhone())
+                  ->setHomePhoneNumber($order->getBillingPhone());
+        }
+
+        // Add metadata
+        $metadata = new PaymentorderMetadata();
+        $metadata->setData('order_id', $order->getOrderId());
+
+        // Add Risk Indicator
+        $riskIndicator = new PaymentorderRiskIndicator($this->getRiskIndicator($orderId)->toArray());
+
+        // Build items collection
+        $items = $order->getItems();
+        $orderItems = new OrderItemsCollection();
+        foreach ($items as $item) {
+            /** @var OrderItem $item */
+
+            $orderItem = new OrderItem();
+            $orderItem
+                ->setReference($item->getReference())
+                ->setName($item->getName())
+                ->setType($item->getType())
+                ->setItemClass($item->getItemClass())
+                ->setItemUrl($item->getItemUrl())
+                ->setImageUrl($item->getImageUrl())
+                ->setDescription($item->getDescription())
+                ->setDiscountDescription($item->getDiscountDescription())
+                ->setQuantity($item->getQty())
+                ->setUnitPrice($item->getUnitPrice())
+                ->setQuantityUnit($item->getQuantityUnit())
+                ->setVatPercent($item->getVatPercent())
+                ->setAmount($item->getAmount())
+                ->setVatAmount($item->getVatAmount());
+
+            $orderItems->addItem($orderItem);
+        }
+
+        $paymentOrder = new Paymentorder();
+        $paymentOrder
+            ->setInitiatingSystemUserAgent($this->adapter->getInitiatingSystemUserAgent())
+            ->setOperation(self::OPERATION_PURCHASE)
+            ->setCurrency($order->getCurrency())
+            ->setAmount($order->getAmountInCents())
+            ->setVatAmount($order->getVatAmountInCents())
+            ->setDescription($order->getDescription())
+            ->setUserAgent($order->getHttpUserAgent())
+            ->setLanguage($order->getLanguage())
+            ->setGenerateRecurrenceToken($generateRecurrenceToken)
+            ->setDisablePaymentMenu(false)
+            ->setUrls($urlData)
+            ->setPayeeInfo($payeeInfo)
+            ->setMetadata($metadata)
+            ->setOrderItems($orderItems)
+            ->setRiskIndicator($riskIndicator)
+            ->setItems([
+                'creditCard' => [
+                    'rejectCreditCards' => $this->configuration->getRejectCreditCards(),
+                    'rejectDebitCards' => $this->configuration->getRejectDebitCards(),
+                    'rejectConsumerCards' => $this->configuration->getRejectConsumerCards(),
+                    'rejectCorporateCards' => $this->configuration->getRejectCorporateCards()
+                ]
+            ])
+            ->setPayer($payer);
+
+        $paymentOrderObject = new PaymentorderObject();
+        $paymentOrderObject->setPaymentorder($paymentOrder);
+
+        // Process payment object
+        $paymentOrderObject = $this->adapter->processPaymentObject($paymentOrderObject, $orderId);
+
+        $purchaseRequest = new Purchase($paymentOrderObject);
+        $purchaseRequest->setClient($this->client);
+
         try {
-            $result = $this->request('POST', '/psp/paymentorders', $params);
-        } catch (\SwedbankPay\Core\Exception $e) {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $purchaseRequest->send();
+
             $this->log(
                 LogLevel::DEBUG,
-                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+                $purchaseRequest->getClient()->getDebugInfo()
             );
 
-            throw new Exception($e->getMessage(), $e->getCode(), null, $e->getProblems());
-        } catch (\Exception $e) {
+            return new Response($responseService->getResponseData());
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $purchaseRequest->getClient()->getDebugInfo()
+            );
+
             $this->log(
                 LogLevel::DEBUG,
                 sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
@@ -102,8 +172,6 @@ trait Checkout
 
             throw new Exception($e->getMessage());
         }
-
-        return $result;
     }
 
     /**
@@ -121,51 +189,78 @@ trait Checkout
 
         $urls = $this->getPlatformUrls($orderId);
 
-        $params = [
-            'paymentorder' => [
-                'operation' => self::OPERATION_VERIFY,
-                'currency' => $order->getCurrency(),
-                'description' => 'Verification of Credit Card',
-                'payerReference' => $order->getPayerReference(),
-                'generateRecurrenceToken' => true,
-                'userAgent' => $order->getHttpUserAgent(),
-                'language' => $order->getLanguage(),
-                'urls' => [
-                    'hostUrls' => $urls->getHostUrls(),
-                    'completeUrl' => $urls->getCompleteUrl(),
-                    'cancelUrl' => $urls->getCancelUrl(),
-                    'callbackUrl' => $urls->getCallbackUrl(),
-                    'termsOfServiceUrl' => $urls->getTermsUrl(),
-                    'logoUrl' => $urls->getLogoUrl(),
-                    'paymentUrl' => $urls->getPaymentUrl()
-                ],
-                'payeeInfo' => $this->getPayeeInfo($orderId)->toArray(),
-                'riskIndicator' => $this->getRiskIndicator($orderId)->toArray(),
+        $urlData = new PaymentorderUrl();
+        $urlData->setHostUrls($urls->getHostUrls())
+                ->setCompleteUrl($urls->getCompleteUrl())
+                ->setCancelUrl($urls->getCompleteUrl())
+                ->setPaymentUrl($urls->getPaymentUrl())
+                ->setCallbackUrl($urls->getCallbackUrl())
+                ->setTermsOfService($urls->getTermsUrl())
+                ->setLogoUrl($urls->getLogoUrl());
+
+        $payeeInfo = new PaymentorderPayeeInfo($this->getPayeeInfo($orderId)->toArray());
+
+        // Add metadata
+        $metadata = new PaymentorderMetadata();
+        $metadata->setData('order_id', $order->getOrderId());
+
+        // Add Risk Indicator
+        $riskIndicator = new PaymentorderRiskIndicator($this->getRiskIndicator($orderId)->toArray());
+
+        $paymentOrder = new Paymentorder();
+        $paymentOrder
+            ->setInitiatingSystemUserAgent($this->adapter->getInitiatingSystemUserAgent())
+            ->setOperation(self::OPERATION_VERIFY)
+            ->setCurrency($order->getCurrency())
+            ->setDescription('Verification of Credit Card')
+            ->setUserAgent($order->getHttpUserAgent())
+            ->setLanguage($order->getLanguage())
+            ->setGenerateRecurrenceToken(true)
+            ->setUrls($urlData)
+            ->setPayeeInfo($payeeInfo)
+            ->setMetadata($metadata)
+            ->setRiskIndicator($riskIndicator)
+            ->setItems([
                 'creditCard' => [
                     'rejectCreditCards' => $this->configuration->getRejectCreditCards(),
                     'rejectDebitCards' => $this->configuration->getRejectDebitCards(),
                     'rejectConsumerCards' => $this->configuration->getRejectConsumerCards(),
                     'rejectCorporateCards' => $this->configuration->getRejectCorporateCards()
-                ],
-                'metadata' => [
-                    'order_id' => $order->getOrderId()
-                ],
-            ]
-        ];
+                ]
+            ]);
 
-        if ($this->configuration->getUseCardholderInfo()) {
-            $params['paymentorder']['cardholder'] = $order->getCardHolderInformation();
-        }
+        $paymentOrderObject = new PaymentorderObject();
+        $paymentOrderObject->setPaymentorder($paymentOrder);
+
+        // Process payment object
+        $paymentOrderObject = $this->adapter->processPaymentObject($paymentOrderObject, $orderId);
+
+        $purchaseRequest = new Verify($paymentOrderObject);
+        $purchaseRequest->setClient($this->client);
 
         try {
-            $result = $this->request('POST', '/psp/paymentorders', $params);
-        } catch (\Exception $e) {
-            $this->log(LogLevel::DEBUG, sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage()));
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $purchaseRequest->send();
+
+            $this->log(
+                LogLevel::DEBUG,
+                $purchaseRequest->getClient()->getDebugInfo()
+            );
+
+            return new Response($responseService->getResponseData());
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $purchaseRequest->getClient()->getDebugInfo()
+            );
+
+            $this->log(
+                LogLevel::DEBUG,
+                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+            );
 
             throw new Exception($e->getMessage());
         }
-
-        return $result;
     }
 
     /**
@@ -182,43 +277,106 @@ trait Checkout
         /** @var Order $order */
         $order = $this->getOrder($orderId);
 
-        $params = [
-            'paymentorder' => [
-                'operation' => self::OPERATION_RECUR,
-                'recurrenceToken' => $recurrenceToken,
-                'intent' => $this->configuration->getAutoCapture() ?
-                    self::INTENT_AUTOCAPTURE : self::INTENT_AUTHORIZATION,
-                'currency' => $order->getCurrency(),
-                'amount' => $order->getAmountInCents(),
-                'vatAmount' => $order->getVatAmountInCents(),
-                'description' => $order->getDescription(),
-                'payerReference' => $order->getPayerReference(),
-                'userAgent' => $order->getHttpUserAgent(),
-                'language' => $order->getLanguage(),
-                'urls' => [
-                    'callbackUrl' => $this->getPlatformUrls($orderId)->getCallbackUrl()
-                ],
-                'payeeInfo' => $this->getPayeeInfo($orderId)->toArray(),
-                'orderItems' => $order->getItems(),
-                'riskIndicator' => $this->getRiskIndicator($orderId)->toArray(),
-                'metadata' => [
-                    'order_id' => $orderId
-                ],
-            ]
-        ];
+        $urls = $this->getPlatformUrls($orderId);
+
+        $urlData = new PaymentorderUrl();
+        $urlData
+            ->setHostUrls($urls->getHostUrls())
+            ->setCompleteUrl($urls->getCompleteUrl())
+            ->setCancelUrl($urls->getCompleteUrl())
+            ->setPaymentUrl($urls->getPaymentUrl())
+            ->setCallbackUrl($urls->getCallbackUrl())
+            ->setTermsOfService($urls->getTermsUrl())
+            ->setLogoUrl($urls->getLogoUrl());
+
+        $payeeInfo = new PaymentorderPayeeInfo($this->getPayeeInfo($orderId)->toArray());
+
+        // Add metadata
+        $metadata = new PaymentorderMetadata();
+        $metadata->setData('order_id', $order->getOrderId());
+
+        // Add Risk Indicator
+        $riskIndicator = new PaymentorderRiskIndicator($this->getRiskIndicator($orderId)->toArray());
+
+        // Build items collection
+        $items = $order->getItems();
+        $orderItems = new OrderItemsCollection();
+        foreach ($items as $item) {
+            /** @var OrderItem $item */
+
+            $orderItem = new OrderItem();
+            $orderItem
+                ->setReference($item->getReference())
+                ->setName($item->getName())
+                ->setType($item->getType())
+                ->setItemClass($item->getItemClass())
+                ->setItemUrl($item->getItemUrl())
+                ->setImageUrl($item->getImageUrl())
+                ->setDescription($item->getDescription())
+                ->setDiscountDescription($item->getDiscountDescription())
+                ->setQuantity($item->getQty())
+                ->setUnitPrice($item->getUnitPrice())
+                ->setQuantityUnit($item->getQuantityUnit())
+                ->setVatPercent($item->getVatPercent())
+                ->setAmount($item->getAmount())
+                ->setVatAmount($item->getVatAmount());
+
+            $orderItems->addItem($orderItem);
+        }
+
+        $paymentOrder = new Paymentorder();
+        $paymentOrder
+            ->setInitiatingSystemUserAgent($this->adapter->getInitiatingSystemUserAgent())
+            ->setOperation(self::OPERATION_RECUR)
+            ->setRecurrenceToken($recurrenceToken)
+            ->setIntent(
+                $this->configuration->getAutoCapture() ?
+                    self::INTENT_AUTOCAPTURE : self::INTENT_AUTHORIZATION
+            )
+            ->setCurrency($order->getCurrency())
+            ->setAmount($order->getAmountInCents())
+            ->setVatAmount($order->getVatAmountInCents())
+            ->setDescription($order->getDescription())
+            ->setUserAgent($order->getHttpUserAgent())
+            ->setLanguage($order->getLanguage())
+            ->setUrls($urlData)
+            ->setPayeeInfo($payeeInfo)
+            ->setMetadata($metadata)
+            ->setRiskIndicator($riskIndicator)
+            ->setOrderItems($orderItems);
+
+        $paymentOrderObject = new PaymentorderObject();
+        $paymentOrderObject->setPaymentorder($paymentOrder);
+
+        // Process payment object
+        $paymentOrderObject = $this->adapter->processPaymentObject($paymentOrderObject, $orderId);
+
+        $purchaseRequest = new Recur($paymentOrderObject);
+        $purchaseRequest->setClient($this->client);
 
         try {
-            $result = $this->request('POST', '/psp/paymentorders', $params);
-        } catch (\Exception $e) {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $purchaseRequest->send();
+
+            $this->log(
+                LogLevel::DEBUG,
+                $purchaseRequest->getClient()->getDebugInfo()
+            );
+
+            return new Response($responseService->getResponseData());
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $purchaseRequest->getClient()->getDebugInfo()
+            );
+
             $this->log(
                 LogLevel::DEBUG,
                 sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
             );
 
-            throw $e;
+            throw new Exception($e->getMessage());
         }
-
-        return $result;
     }
 
     /**
@@ -324,53 +482,97 @@ trait Checkout
             throw new Exception('Unable to get the payment order ID');
         }
 
-        /** @var Response $result */
-        $result = $this->request('GET', $paymentOrderId);
-        $href = $result->getOperationByRel('create-paymentorder-capture');
-        if (empty($href)) {
-            throw new Exception('Capture is unavailable');
+        // Build items collection
+        $orderItems = new OrderItemsCollection();
+        foreach ($items as $item) {
+            /** @var OrderItem $item */
+            $orderItem = new OrderItem();
+            $orderItem
+                ->setReference($item->getReference())
+                ->setName($item->getName())
+                ->setType($item->getType())
+                ->setItemClass($item->getItemClass())
+                ->setItemUrl($item->getItemUrl())
+                ->setImageUrl($item->getImageUrl())
+                ->setDescription($item->getDescription())
+                ->setDiscountDescription($item->getDiscountDescription())
+                ->setQuantity($item->getQty())
+                ->setUnitPrice($item->getUnitPrice())
+                ->setQuantityUnit($item->getQuantityUnit())
+                ->setVatPercent($item->getVatPercent())
+                ->setAmount($item->getAmount())
+                ->setVatAmount($item->getVatAmount());
+
+            $orderItems->addItem($orderItem);
         }
 
-        $params = [
-            'transaction' => [
-                'amount'         => (int)bcmul(100, $amount),
-                'vatAmount'      => (int)bcmul(100, $vatAmount),
-                'description'    => sprintf('Capture for Order #%s', $order->getOrderId()),
-                'payeeReference' => $this->generatePayeeReference($orderId),
-                'orderItems' => $items
-            ]
-        ];
+        $transactionData = new Transaction();
+        $transactionData
+            ->setAmount((int)bcmul(100, $amount))
+            ->setVatAmount((int)bcmul(100, $vatAmount))
+            ->setDescription(sprintf('Capture for Order #%s', $order->getOrderId()))
+            ->setPayeeReference($this->generatePayeeReference($orderId))
+            ->setOrderItems($orderItems);
 
-        $result = $this->request('POST', $href, $params);
+        $transaction = new TransactionObject();
+        $transaction->setTransaction($transactionData);
 
-        // Save transaction
-        $transaction = $result['capture']['transaction'];
-        $this->saveTransaction($orderId, $transaction);
+        $requestService = new TransactionCapture($transaction);
+        $requestService->setClient($this->client)
+                       ->setPaymentOrderId($paymentOrderId);
 
-        switch ($transaction['state']) {
-            case 'Completed':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_CAPTURED,
-                    sprintf('Transaction is captured. Amount: %s', $amount),
-                    $transaction['number']
-                );
-                break;
-            case 'Initialized':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_AUTHORIZED,
-                    sprintf('Transaction capture status: %s. Amount: %s', $transaction['state'], $amount)
-                );
-                break;
-            case 'Failed':
-                $message = isset($transaction['failedReason']) ? $transaction['failedReason'] : 'Capture is failed.';
-                throw new Exception($message);
-            default:
-                throw new Exception('Capture is failed.');
+        try {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $requestService->send();
+
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $result = $responseService->getResponseData();
+
+            // Save transaction
+            $transaction = $result['capture']['transaction'];
+            $this->saveTransaction($orderId, $transaction);
+
+            switch ($transaction['state']) {
+                case TransactionInterface::STATE_COMPLETED:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_CAPTURED,
+                        sprintf('Transaction is captured. Amount: %s', $amount),
+                        $transaction['number']
+                    );
+                    break;
+                case TransactionInterface::STATE_INITIALIZED:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_AUTHORIZED,
+                        sprintf('Transaction capture status: %s. Amount: %s', $transaction['state'], $amount)
+                    );
+                    break;
+                case TransactionInterface::STATE_FAILED:
+                    $message = $transaction['failedReason'] ?? 'Capture is failed.';
+                    throw new Exception($message);
+                default:
+                    throw new Exception('Capture is failed.');
+            }
+
+            return new Response($result);
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $this->log(
+                LogLevel::DEBUG,
+                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+            );
+
+            throw new Exception($e->getMessage());
         }
-
-        return $result;
     }
 
     /**
@@ -403,52 +605,71 @@ trait Checkout
             throw new Exception('Unable to get the payment order ID');
         }
 
-        /** @var Response $result */
-        $result = $this->request('GET', $paymentOrderId);
-        $href = $result->getOperationByRel('create-paymentorder-cancel');
-        if (empty($href)) {
-            throw new Exception('Cancellation is unavailable');
+        $transactionData = new Transaction();
+        $transactionData
+            ->setDescription(sprintf('Cancellation for Order #%s', $order->getOrderId()))
+            ->setPayeeReference($this->generatePayeeReference($orderId));
+
+        $transaction = new TransactionObject();
+        $transaction->setTransaction($transactionData);
+
+        $requestService = new TransactionCancel($transaction);
+        $requestService->setClient($this->client)
+                       ->setPaymentOrderId($paymentOrderId);
+
+        try {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $requestService->send();
+
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $result = $responseService->getResponseData();
+
+            // Save transaction
+            $transaction = $result['cancellation']['transaction'];
+            $this->saveTransaction($orderId, $transaction);
+
+            switch ($transaction['state']) {
+                case TransactionInterface::STATE_COMPLETED:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_CANCELLED,
+                        'Transaction is cancelled.',
+                        $transaction['number']
+                    );
+                    break;
+                case TransactionInterface::STATE_INITIALIZED:
+                case TransactionInterface::STATE_AWAITING_ACTIVITY:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_CANCELLED,
+                        sprintf('Transaction cancellation status: %s.', $transaction['state'])
+                    );
+                    break;
+                case TransactionInterface::STATE_FAILED:
+                    $message = $transaction['failedReason'] ?? 'Cancellation is failed.';
+                    throw new Exception($message);
+                default:
+                    throw new Exception('Capture is failed.');
+            }
+
+            return new Response($result);
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $this->log(
+                LogLevel::DEBUG,
+                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+            );
+
+            throw new Exception($e->getMessage());
         }
-
-        $params = [
-            'transaction' => [
-                'description'    => sprintf('Cancellation for Order #%s', $order->getOrderId()),
-                'payeeReference' => $this->generatePayeeReference($orderId),
-            ]
-        ];
-
-        $result = $this->request('POST', $href, $params);
-
-        // Save transaction
-        $transaction = $result['cancellation']['transaction'];
-        $this->saveTransaction($orderId, $transaction);
-
-        switch ($transaction['state']) {
-            case 'Completed':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_CANCELLED,
-                    'Transaction is cancelled.',
-                    $transaction['number']
-                );
-                break;
-            case 'Initialized':
-            case 'AwaitingActivity':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_CANCELLED,
-                    sprintf('Transaction cancellation status: %s.', $transaction['state'])
-                );
-                break;
-            case 'Failed':
-                $message = isset($transaction['failedReason']) ?
-                    $transaction['failedReason'] : 'Cancellation is failed.';
-                throw new Exception($message);
-            default:
-                throw new Exception('Capture is failed.');
-        }
-
-        return $result;
     }
 
     /**
@@ -476,101 +697,133 @@ trait Checkout
             throw new Exception('Unable to get the payment order ID');
         }
 
-        /** @var Response $result */
-        $result = $this->request('GET', $paymentOrderId);
-        $href = $result->getOperationByRel('create-paymentorder-reversal');
-        if (empty($href)) {
-            throw new Exception('Refund is unavailable');
-        }
-
-        if (!$amount) {
-            $amount = $order->getAmount();
-            $vatAmount = $order->getVatAmount();
-        }
-
-        // Use all order items if undefined
         if (count($items) === 0) {
             $items = $order->getItems();
+        }
 
-            // Recalculate amount and VAT amount
-            $amount = 0;
-            $vatAmount = 0;
-            foreach ($items as $key => $item) {
-                $amount += $item->getAmount();
-                $vatAmount += $item->getVatAmount();
+        // Build items collection
+        $orderItems = new OrderItemsCollection();
 
-                if ($item->getData('restrictedToInstruments')) {
-                    $item->unsData('restrictedToInstruments');
-                    $items[$key] = $item;
-                }
-            }
+        // Recalculate amount and VAT amount
+        $amount = 0;
+        $vatAmount = 0;
+        foreach ($items as $item) {
+            $amount += $item->getAmount();
+            $vatAmount += $item->getVatAmount();
+
+            /** @var OrderItem $item */
+            $orderItem = new OrderItem();
+            $orderItem
+                ->setReference($item->getReference())
+                ->setName($item->getName())
+                ->setType($item->getType())
+                ->setItemClass($item->getItemClass())
+                ->setItemUrl($item->getItemUrl())
+                ->setImageUrl($item->getImageUrl())
+                ->setDescription($item->getDescription())
+                ->setDiscountDescription($item->getDiscountDescription())
+                ->setQuantity($item->getQty())
+                ->setUnitPrice($item->getUnitPrice())
+                ->setQuantityUnit($item->getQuantityUnit())
+                ->setVatPercent($item->getVatPercent())
+                ->setAmount($item->getAmount())
+                ->setVatAmount($item->getVatAmount());
+
+            $orderItems->addItem($orderItem);
 
             $amount = $amount / 100;
             $vatAmount = $vatAmount / 100;
         }
 
-        $params = [
-            'transaction' => [
-                'description' => sprintf('Refund for Order #%s. Amount: %s', $order->getOrderId(), $amount),
-                'amount' => (int)bcmul(100, $amount),
-                'vatAmount' => (int)bcmul(100, $vatAmount),
-                'payeeReference' => $this->generatePayeeReference($orderId),
-                'receiptReference' => $this->generatePayeeReference($orderId),
-                'orderItems' => $items
-            ]
-        ];
+        $transactionData = new Transaction();
+        $transactionData
+            ->setAmount((int)bcmul(100, $amount))
+            ->setVatAmount((int)bcmul(100, $vatAmount))
+            ->setDescription(sprintf('Refund for Order #%s. Amount: %s', $order->getOrderId(), $amount))
+            ->setPayeeReference($this->generatePayeeReference($orderId))
+            ->setReceiptReference($this->generatePayeeReference($orderId))
+            ->setOrderItems($orderItems);
 
-        $result = $this->request('POST', $href, $params);
+        $transaction = new TransactionObject();
+        $transaction->setTransaction($transactionData);
 
-        // Save transaction
-        $transaction = $result['reversal']['transaction'];
-        $this->saveTransaction($orderId, $transaction);
+        $requestService = new TransactionReversal($transaction);
+        $requestService->setClient($this->client)
+                       ->setPaymentOrderId($paymentOrderId);
 
-        switch ($transaction['state']) {
-            case 'Completed':
-                $info = $this->fetchPaymentInfo($paymentOrderId);
+        try {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $requestService->send();
 
-                // Check if the payment was refund fully
-                $isFullRefund = false;
-                if (!isset($info['paymentOrder']['remainingReversalAmount'])) {
-                    // Failback if `remainingReversalAmount` is missing
-                    if (bccomp($order->getAmount(), $amount, 2) === 0) {
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $result = $responseService->getResponseData();
+
+            // Save transaction
+            $transaction = $result['reversal']['transaction'];
+            $this->saveTransaction($orderId, $transaction);
+
+            switch ($transaction['state']) {
+                case TransactionInterface::STATE_COMPLETED:
+                    $info = $this->fetchPaymentInfo($paymentOrderId);
+
+                    // Check if the payment was refund fully
+                    $isFullRefund = false;
+                    if (!isset($info['paymentOrder']['remainingReversalAmount'])) {
+                        // Failback if `remainingReversalAmount` is missing
+                        if (bccomp($order->getAmount(), $amount, 2) === 0) {
+                            $isFullRefund = true;
+                        }
+                    } elseif ((int) $info['paymentOrder']['remainingReversalAmount'] === 0) {
                         $isFullRefund = true;
                     }
-                } elseif ((int) $info['paymentOrder']['remainingReversalAmount'] === 0) {
-                    $isFullRefund = true;
-                }
 
-                if ($isFullRefund) {
-                    $this->updateOrderStatus(
-                        $orderId,
-                        OrderInterface::STATUS_REFUNDED,
-                        sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state']),
-                        $transaction['number']
-                    );
-                } else {
+                    if ($isFullRefund) {
+                        $this->updateOrderStatus(
+                            $orderId,
+                            OrderInterface::STATUS_REFUNDED,
+                            sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state']),
+                            $transaction['number']
+                        );
+                    } else {
+                        $this->addOrderNote(
+                            $orderId,
+                            sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state'])
+                        );
+                    }
+
+                    break;
+                case TransactionInterface::STATE_INITIALIZED:
+                case TransactionInterface::STATE_AWAITING_ACTIVITY:
                     $this->addOrderNote(
                         $orderId,
                         sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state'])
                     );
-                }
 
-                break;
-            case 'Initialized':
-            case 'AwaitingActivity':
-                $this->addOrderNote(
-                    $orderId,
-                    sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state'])
-                );
+                    break;
+                case TransactionInterface::STATE_FAILED:
+                    $message = $transaction['failedReason'] ?? 'Refund is failed.';
+                    throw new Exception($message);
+                default:
+                    throw new Exception('Refund is failed.');
+            }
 
-                break;
-            case 'Failed':
-                $message = isset($transaction['failedReason']) ? $transaction['failedReason'] : 'Refund is failed.';
-                throw new Exception($message);
-            default:
-                throw new Exception('Refund is failed.');
+            return new Response($result);
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $this->log(
+                LogLevel::DEBUG,
+                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+            );
+
+            throw new Exception($e->getMessage());
         }
-
-        return $result;
     }
 }

--- a/src/SwedbankPay/Core/Library/Methods/Checkout.php
+++ b/src/SwedbankPay/Core/Library/Methods/Checkout.php
@@ -42,6 +42,7 @@ trait Checkout
      * @throws Exception
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.LongVariable)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function initiatePaymentOrderPurchase(
         $orderId,
@@ -271,6 +272,7 @@ trait Checkout
      *
      * @return Response
      * @throws \Exception
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function initiatePaymentOrderRecur($orderId, $recurrenceToken)
     {
@@ -466,6 +468,9 @@ trait Checkout
      *
      * @return Response
      * @throws Exception
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function captureCheckout($orderId, $amount = null, $vatAmount = 0, array $items = [])
     {
@@ -586,6 +591,7 @@ trait Checkout
      * @throws Exception
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function cancelCheckout($orderId, $amount = null, $vatAmount = 0)
     {

--- a/src/SwedbankPay/Core/Library/Methods/Checkout.php
+++ b/src/SwedbankPay/Core/Library/Methods/Checkout.php
@@ -9,6 +9,7 @@ use SwedbankPay\Core\Log\LogLevel;
 use SwedbankPay\Core\Order;
 use SwedbankPay\Core\OrderInterface;
 use SwedbankPay\Core\Api\TransactionInterface;
+use SwedbankPay\Core\OrderItemInterface;
 
 use SwedbankPay\Api\Client\Exception as ClientException;
 use SwedbankPay\Api\Service\Paymentorder\Resource\Request\Paymentorder;
@@ -79,21 +80,21 @@ trait Checkout
         $items = $order->getItems();
         $orderItems = new OrderItemsCollection();
         foreach ($items as $item) {
-            /** @var OrderItem $item */
+            /** @var OrderItemInterface $item */
 
             $orderItem = new OrderItem();
             $orderItem
                 ->setReference($item->getReference())
                 ->setName($item->getName())
                 ->setType($item->getType())
-                ->setItemClass($item->getItemClass())
+                ->setItemClass($item->getClass())
                 ->setItemUrl($item->getItemUrl())
                 ->setImageUrl($item->getImageUrl())
                 ->setDescription($item->getDescription())
-                ->setDiscountDescription($item->getDiscountDescription())
+                //->setDiscountDescription($item->getDiscountDescription())
                 ->setQuantity($item->getQty())
                 ->setUnitPrice($item->getUnitPrice())
-                ->setQuantityUnit($item->getQuantityUnit())
+                ->setQuantityUnit($item->getQtyUnit())
                 ->setVatPercent($item->getVatPercent())
                 ->setAmount($item->getAmount())
                 ->setVatAmount($item->getVatAmount());
@@ -216,6 +217,14 @@ trait Checkout
         // Add Risk Indicator
         $riskIndicator = new PaymentorderRiskIndicator($this->getRiskIndicator($orderId)->toArray());
 
+        $items = new PaymentorderItemsCollection();
+        $items->addItem(['creditCard' => [
+            'rejectCreditCards' => $this->configuration->getRejectCreditCards(),
+            'rejectDebitCards' => $this->configuration->getRejectDebitCards(),
+            'rejectConsumerCards' => $this->configuration->getRejectConsumerCards(),
+            'rejectCorporateCards' => $this->configuration->getRejectCorporateCards()
+        ]]);
+
         $paymentOrder = new Paymentorder();
         $paymentOrder
             ->setInitiatingSystemUserAgent($this->adapter->getInitiatingSystemUserAgent())
@@ -229,14 +238,7 @@ trait Checkout
             ->setPayeeInfo($payeeInfo)
             ->setMetadata($metadata)
             ->setRiskIndicator($riskIndicator)
-            ->setItems([
-                'creditCard' => [
-                    'rejectCreditCards' => $this->configuration->getRejectCreditCards(),
-                    'rejectDebitCards' => $this->configuration->getRejectDebitCards(),
-                    'rejectConsumerCards' => $this->configuration->getRejectConsumerCards(),
-                    'rejectCorporateCards' => $this->configuration->getRejectCorporateCards()
-                ]
-            ]);
+            ->setItems($items);
 
         $paymentOrderObject = new PaymentorderObject();
         $paymentOrderObject->setPaymentorder($paymentOrder);
@@ -312,21 +314,21 @@ trait Checkout
         $items = $order->getItems();
         $orderItems = new OrderItemsCollection();
         foreach ($items as $item) {
-            /** @var OrderItem $item */
+            /** @var OrderItemInterface $item */
 
             $orderItem = new OrderItem();
             $orderItem
                 ->setReference($item->getReference())
                 ->setName($item->getName())
                 ->setType($item->getType())
-                ->setItemClass($item->getItemClass())
+                ->setItemClass($item->getClass())
                 ->setItemUrl($item->getItemUrl())
                 ->setImageUrl($item->getImageUrl())
                 ->setDescription($item->getDescription())
-                ->setDiscountDescription($item->getDiscountDescription())
+                //->setDiscountDescription($item->getDiscountDescription())
                 ->setQuantity($item->getQty())
                 ->setUnitPrice($item->getUnitPrice())
-                ->setQuantityUnit($item->getQuantityUnit())
+                ->setQuantityUnit($item->getQtyUnit())
                 ->setVatPercent($item->getVatPercent())
                 ->setAmount($item->getAmount())
                 ->setVatAmount($item->getVatAmount());
@@ -498,20 +500,21 @@ trait Checkout
         // Build items collection
         $orderItems = new OrderItemsCollection();
         foreach ($items as $item) {
-            /** @var OrderItem $item */
+            /** @var OrderItemInterface $item */
+
             $orderItem = new OrderItem();
             $orderItem
                 ->setReference($item->getReference())
                 ->setName($item->getName())
                 ->setType($item->getType())
-                ->setItemClass($item->getItemClass())
+                ->setItemClass($item->getClass())
                 ->setItemUrl($item->getItemUrl())
                 ->setImageUrl($item->getImageUrl())
                 ->setDescription($item->getDescription())
-                ->setDiscountDescription($item->getDiscountDescription())
+                //->setDiscountDescription($item->getDiscountDescription())
                 ->setQuantity($item->getQty())
                 ->setUnitPrice($item->getUnitPrice())
-                ->setQuantityUnit($item->getQuantityUnit())
+                ->setQuantityUnit($item->getQtyUnit())
                 ->setVatPercent($item->getVatPercent())
                 ->setAmount($item->getAmount())
                 ->setVatAmount($item->getVatAmount());
@@ -725,20 +728,21 @@ trait Checkout
             $amount += $item->getAmount();
             $vatAmount += $item->getVatAmount();
 
-            /** @var OrderItem $item */
+            /** @var OrderItemInterface $item */
+
             $orderItem = new OrderItem();
             $orderItem
                 ->setReference($item->getReference())
                 ->setName($item->getName())
                 ->setType($item->getType())
-                ->setItemClass($item->getItemClass())
+                ->setItemClass($item->getClass())
                 ->setItemUrl($item->getItemUrl())
                 ->setImageUrl($item->getImageUrl())
                 ->setDescription($item->getDescription())
-                ->setDiscountDescription($item->getDiscountDescription())
+                //->setDiscountDescription($item->getDiscountDescription())
                 ->setQuantity($item->getQty())
                 ->setUnitPrice($item->getUnitPrice())
-                ->setQuantityUnit($item->getQuantityUnit())
+                ->setQuantityUnit($item->getQtyUnit())
                 ->setVatPercent($item->getVatPercent())
                 ->setAmount($item->getAmount())
                 ->setVatAmount($item->getVatAmount());

--- a/src/SwedbankPay/Core/Library/Methods/Invoice.php
+++ b/src/SwedbankPay/Core/Library/Methods/Invoice.php
@@ -9,7 +9,9 @@ use SwedbankPay\Core\Log\LogLevel;
 use SwedbankPay\Core\Order;
 use SwedbankPay\Core\OrderInterface;
 use SwedbankPay\Core\OrderItemInterface;
+use SwedbankPay\Core\Api\TransactionInterface;
 
+use SwedbankPay\Api\Client\Exception as ClientException;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\PricesCollection;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\Item\PriceItem;
 use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
@@ -20,6 +22,13 @@ use SwedbankPay\Api\Service\Invoice\Resource\Request\Payment;
 use SwedbankPay\Api\Service\Invoice\Resource\Request\Invoice as InvoiceRequest;
 use SwedbankPay\Api\Service\Invoice\Resource\Request\InvoicePaymentObject as PaymentObject;
 use SwedbankPay\Api\Service\Data\ResponseInterface as ResponseServiceInterface;
+use SwedbankPay\Api\Service\Payment\Transaction\Resource\Request\TransactionObject;
+use SwedbankPay\Api\Service\Invoice\Transaction\Request\CreateCapture;
+use SwedbankPay\Api\Service\Invoice\Transaction\Request\CreateReversal;
+use SwedbankPay\Api\Service\Invoice\Transaction\Request\CreateCancellation;
+use SwedbankPay\Api\Service\Invoice\Transaction\Resource\Request\Capture as TransactionCapture;
+use SwedbankPay\Api\Service\Invoice\Transaction\Resource\Request\Reversal as TransactionReversal;
+use SwedbankPay\Api\Service\Invoice\Transaction\Resource\Request\Cancellation as TransactionCancellation;
 
 trait Invoice
 {
@@ -282,11 +291,6 @@ trait Invoice
             throw new Exception('Unable to get payment ID');
         }
 
-        $href = $this->fetchPaymentInfo($paymentId)->getOperationByRel('create-capture');
-        if (empty($href)) {
-            throw new Exception('Capture is unavailable');
-        }
-
         // Covert order lines
         $itemDescriptions = [];
         $vatSummary = [];
@@ -303,48 +307,75 @@ trait Invoice
             ];
         }
 
-        $params = [
-            'transaction' => [
-                'activity' => 'FinancingConsumer',
-                'amount' => (int)bcmul(100, $amount),
-                'vatAmount' => (int)bcmul(100, $vatAmount),
-                'description' => sprintf('Capture for Order #%s', $order->getOrderId()),
-                'payeeReference' => $this->generatePayeeReference($orderId),
-                'itemDescriptions' => $itemDescriptions,
-                'vatSummary' => $vatSummary
-            ],
-        ];
+        $transactionData = new TransactionCapture();
+        $transactionData
+            ->setActivity('FinancingConsumer')
+            ->setAmount((int)bcmul(100, $amount))
+            ->setVatAmount((int)bcmul(100, $vatAmount))
+            ->setDescription(sprintf('Capture for Order #%s', $order->getOrderId()))
+            ->setPayeeReference($this->generatePayeeReference($orderId))
+            ->setReceiptReference($this->generatePayeeReference($orderId))
+            ->setItemDescriptions($itemDescriptions)
+            ->setVatSummary($vatSummary);
 
-        $result = $this->request('POST', $href, $params);
+        $transaction = new TransactionObject();
+        $transaction->setTransaction($transactionData);
 
-        // Save transaction
-        $transaction = $result['capture']['transaction'];
-        $this->saveTransaction($orderId, $transaction);
+        $requestService = new CreateCapture($transaction);
+        $requestService->setClient($this->client);
+        $requestService->setPaymentId($paymentId);
 
-        switch ($transaction['state']) {
-            case 'Completed':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_CAPTURED,
-                    sprintf('Transaction is captured. Amount: %s', $amount),
-                    $transaction['number']
-                );
-                break;
-            case 'Initialized':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_AUTHORIZED,
-                    sprintf('Transaction capture status: %s. Amount: %s', $transaction['state'], $amount)
-                );
-                break;
-            case 'Failed':
-                $message = isset($transaction['failedReason']) ? $transaction['failedReason'] : 'Capture is failed.';
-                throw new Exception($message);
-            default:
-                throw new Exception('Capture is failed.');
+        try {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $requestService->send();
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $result = $responseService->getResponseData();
+
+            // Save transaction
+            $transaction = $result['capture']['transaction'];
+            $this->saveTransaction($orderId, $transaction);
+
+            switch ($transaction['state']) {
+                case TransactionInterface::STATE_COMPLETED:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_CAPTURED,
+                        sprintf('Transaction is captured. Amount: %s', $amount),
+                        $transaction['number']
+                    );
+                    break;
+                case TransactionInterface::STATE_INITIALIZED:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_AUTHORIZED,
+                        sprintf('Transaction capture status: %s. Amount: %s', $transaction['state'], $amount)
+                    );
+                    break;
+                case TransactionInterface::STATE_FAILED:
+                    $message = $transaction['failedReason'] ?? 'Capture is failed.';
+                    throw new Exception($message);
+                default:
+                    throw new Exception('Capture is failed.');
+            }
+
+            return new Response($result);
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $this->log(
+                LogLevel::DEBUG,
+                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+            );
+
+            throw new Exception($e->getMessage());
         }
-
-        return $result;
     }
 
     /**
@@ -378,52 +409,73 @@ trait Invoice
             throw new Exception('Unable to get payment ID');
         }
 
-        $href = $this->fetchPaymentInfo($paymentId)->getOperationByRel('create-cancellation');
-        if (empty($href)) {
-            throw new Exception('Cancellation is unavailable');
+        $transactionData = new TransactionCancellation();
+        $transactionData
+            ->setActivity('FinancingConsumer')
+            ->setDescription(sprintf('Refund for Order #%s.', $order->getOrderId()))
+            ->setPayeeReference($this->generatePayeeReference($orderId));
+
+        $transaction = new TransactionObject();
+        $transaction->setTransaction($transactionData);
+
+        $requestService = new CreateCancellation($transaction);
+        $requestService
+            ->setClient($this->client)
+            ->setPaymentId($paymentId);
+
+        try {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $requestService->send();
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $result = $responseService->getResponseData();
+
+            // Save transaction
+            $transaction = $result['cancellation']['transaction'];
+            $this->saveTransaction($orderId, $transaction);
+
+            switch ($transaction['state']) {
+                case TransactionInterface::STATE_COMPLETED:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_CANCELLED,
+                        'Transaction is cancelled.',
+                        $transaction['number']
+                    );
+                    break;
+                case TransactionInterface::STATE_INITIALIZED:
+                case TransactionInterface::STATE_AWAITING_ACTIVITY:
+                    $this->updateOrderStatus(
+                        $orderId,
+                        OrderInterface::STATUS_CANCELLED,
+                        sprintf('Transaction cancellation status: %s.', $transaction['state'])
+                    );
+                    break;
+                case TransactionInterface::STATE_FAILED:
+                    $message = $transaction['failedReason'] ?? 'Cancellation is failed.';
+
+                    throw new Exception($message);
+                default:
+                    throw new Exception('Capture is failed.');
+            }
+
+            return new Response($result);
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $this->log(
+                LogLevel::DEBUG,
+                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+            );
+
+            throw new Exception($e->getMessage());
         }
-
-        $params = [
-            'transaction' => [
-                'activity' => 'FinancingConsumer',
-                'description' => sprintf('Cancellation for Order #%s', $order->getOrderId()),
-                'payeeReference' => $this->generatePayeeReference($orderId)
-            ],
-        ];
-
-        $result = $this->request('POST', $href, $params);
-
-        // Save transaction
-        $transaction = $result['cancellation']['transaction'];
-        $this->saveTransaction($orderId, $transaction);
-
-        switch ($transaction['state']) {
-            case 'Completed':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_CANCELLED,
-                    'Transaction is cancelled.',
-                    $transaction['number']
-                );
-                break;
-            case 'Initialized':
-            case 'AwaitingActivity':
-                $this->updateOrderStatus(
-                    $orderId,
-                    OrderInterface::STATUS_CANCELLED,
-                    sprintf('Transaction cancellation status: %s.', $transaction['state'])
-                );
-                break;
-            case 'Failed':
-                $message = isset($transaction['failedReason']) ?
-                    $transaction['failedReason'] : 'Cancellation is failed.';
-
-                throw new Exception($message);
-            default:
-                throw new Exception('Capture is failed.');
-        }
-
-        return $result;
     }
 
     /**
@@ -458,72 +510,95 @@ trait Invoice
             throw new Exception('Unable to get payment ID');
         }
 
-        $href = $this->fetchPaymentInfo($paymentId)->getOperationByRel('create-reversal');
-        if (empty($href)) {
-            throw new Exception('Refund is unavailable');
-        }
+        $transactionData = new TransactionReversal();
+        $transactionData
+            ->setActivity('FinancingConsumer')
+            ->setAmount((int)bcmul(100, $amount))
+            ->setVatAmount((int)bcmul(100, $vatAmount))
+            ->setDescription(sprintf('Refund for Order #%s.', $order->getOrderId()))
+            ->setPayeeReference($this->generatePayeeReference($orderId))
+            ->setReceiptReference($this->generatePayeeReference($orderId));
 
-        $params = [
-            'transaction' => [
-                'activity' => 'FinancingConsumer',
-                'amount' => (int)bcmul(100, $amount),
-                'vatAmount' => (int)bcmul(100, $vatAmount),
-                'description' => sprintf('Refund for Order #%s.', $order->getOrderId()),
-                'payeeReference' => $this->generatePayeeReference($orderId)
-            ]
-        ];
+        $transaction = new TransactionObject();
+        $transaction->setTransaction($transactionData);
 
-        $result = $this->request('POST', $href, $params);
+        $requestService = new CreateReversal($transaction);
+        $requestService
+            ->setClient($this->client)
+            ->setPaymentId($paymentId);
 
-        // Save transaction
-        $transaction = $result['reversal']['transaction'];
-        $this->saveTransaction($orderId, $transaction);
+        try {
+            /** @var ResponseServiceInterface $responseService */
+            $responseService = $requestService->send();
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
 
-        switch ($transaction['state']) {
-            case 'Completed':
-                $info = $this->fetchPaymentInfo($paymentId);
+            $result = $responseService->getResponseData();
 
-                // Check if the payment was refund fully
-                $isFullRefund = false;
-                if (!isset($info['payment']['remainingReversalAmount'])) {
-                    // Failback if `remainingReversalAmount` is missing
-                    if (bccomp($order->getAmount(), $amount, 2) === 0) {
+            // Save transaction
+            $transaction = $result['reversal']['transaction'];
+            $this->saveTransaction($orderId, $transaction);
+
+            switch ($transaction['state']) {
+                case TransactionInterface::STATE_COMPLETED:
+                    $info = $this->fetchPaymentInfo($paymentId);
+
+                    // Check if the payment was refund fully
+                    $isFullRefund = false;
+                    if (!isset($info['payment']['remainingReversalAmount'])) {
+                        // Failback if `remainingReversalAmount` is missing
+                        if (bccomp($order->getAmount(), $amount, 2) === 0) {
+                            $isFullRefund = true;
+                        }
+                    } elseif ((int) $info['payment']['remainingReversalAmount'] === 0) {
                         $isFullRefund = true;
                     }
-                } elseif ((int) $info['payment']['remainingReversalAmount'] === 0) {
-                    $isFullRefund = true;
-                }
 
-                if ($isFullRefund) {
-                    $this->updateOrderStatus(
-                        $orderId,
-                        OrderInterface::STATUS_REFUNDED,
-                        sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state']),
-                        $transaction['number']
-                    );
-                } else {
+                    if ($isFullRefund) {
+                        $this->updateOrderStatus(
+                            $orderId,
+                            OrderInterface::STATUS_REFUNDED,
+                            sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state']),
+                            $transaction['number']
+                        );
+                    } else {
+                        $this->addOrderNote(
+                            $orderId,
+                            sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state'])
+                        );
+                    }
+
+                    break;
+                case TransactionInterface::STATE_INITIALIZED:
+                case TransactionInterface::STATE_AWAITING_ACTIVITY:
                     $this->addOrderNote(
                         $orderId,
                         sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state'])
                     );
-                }
 
-                break;
-            case 'Initialized':
-            case 'AwaitingActivity':
-                $this->addOrderNote(
-                    $orderId,
-                    sprintf('Refunded: %s. Transaction state: %s', $amount, $transaction['state'])
-                );
+                    break;
+                case TransactionInterface::STATE_FAILED:
+                    $message = $transaction['failedReason'] ?? 'Refund is failed.';
+                    throw new Exception($message);
+                default:
+                    throw new Exception('Refund is failed.');
+            }
 
-                break;
-            case 'Failed':
-                $message = isset($transaction['failedReason']) ? $transaction['failedReason'] : 'Refund is failed.';
-                throw new Exception($message);
-            default:
-                throw new Exception('Refund is failed.');
+            return new Response($result);
+        } catch (ClientException $e) {
+            $this->log(
+                LogLevel::DEBUG,
+                $requestService->getClient()->getDebugInfo()
+            );
+
+            $this->log(
+                LogLevel::DEBUG,
+                sprintf('%s::%s: API Exception: %s', __CLASS__, __METHOD__, $e->getMessage())
+            );
+
+            throw new Exception($e->getMessage());
         }
-
-        return $result;
     }
 }

--- a/src/SwedbankPay/Core/Library/Methods/Invoice.php
+++ b/src/SwedbankPay/Core/Library/Methods/Invoice.php
@@ -271,6 +271,7 @@ trait Invoice
      * @throws Exception
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function captureInvoice($orderId, $amount = null, $vatAmount = 0, array $items = [])
     {
@@ -389,6 +390,7 @@ trait Invoice
      * @throws Exception
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function cancelInvoice($orderId, $amount = null, $vatAmount = 0)
     {

--- a/src/SwedbankPay/Core/Library/Methods/Invoice.php
+++ b/src/SwedbankPay/Core/Library/Methods/Invoice.php
@@ -491,6 +491,7 @@ trait Invoice
      * @throws Exception
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @SuppressWarnings(PHPMD.ElseExpression)
      */
     public function refundInvoice($orderId, $amount = null, $vatAmount = 0)

--- a/src/SwedbankPay/Core/Library/Methods/Mobilepay.php
+++ b/src/SwedbankPay/Core/Library/Methods/Mobilepay.php
@@ -91,6 +91,9 @@ trait Mobilepay
         $paymentObject->setPayment($payment)
             ->setShoplogoUrl($urls->getLogoUrl());
 
+        // Process payment object
+        $paymentObject = $this->adapter->processPaymentObject($paymentObject, $orderId);
+
         $purchaseRequest = new Purchase($paymentObject);
         $purchaseRequest->setClient($this->client);
 

--- a/src/SwedbankPay/Core/Library/Methods/Swish.php
+++ b/src/SwedbankPay/Core/Library/Methods/Swish.php
@@ -92,6 +92,9 @@ trait Swish
         $paymentObject = new PaymentObject();
         $paymentObject->setPayment($payment);
 
+        // Process payment object
+        $paymentObject = $this->adapter->processPaymentObject($paymentObject, $orderId);
+
         $purchaseRequest = new Purchase($paymentObject);
         $purchaseRequest->setClient($this->client);
 

--- a/src/SwedbankPay/Core/Library/Methods/Trustly.php
+++ b/src/SwedbankPay/Core/Library/Methods/Trustly.php
@@ -88,6 +88,9 @@ trait Trustly
         $paymentObject = new PaymentObject();
         $paymentObject->setPayment($payment);
 
+        // Process payment object
+        $paymentObject = $this->adapter->processPaymentObject($paymentObject, $orderId);
+
         $purchaseRequest = new Purchase($paymentObject);
         $purchaseRequest->setClient($this->client);
 

--- a/src/SwedbankPay/Core/Library/Methods/Vipps.php
+++ b/src/SwedbankPay/Core/Library/Methods/Vipps.php
@@ -85,6 +85,9 @@ trait Vipps
         $paymentObject = new PaymentObject();
         $paymentObject->setPayment($payment);
 
+        // Process payment object
+        $paymentObject = $this->adapter->processPaymentObject($paymentObject, $orderId);
+
         $purchaseRequest = new Purchase($paymentObject);
         $purchaseRequest->setClient($this->client);
 

--- a/src/SwedbankPay/Core/Order.php
+++ b/src/SwedbankPay/Core/Order.php
@@ -181,6 +181,7 @@ class Order extends Data implements OrderInterface
     /**
      * Get card holder's information.
      *
+     * @deprecated
      * @return array
      */
     public function getCardHolderInformation()

--- a/src/SwedbankPay/Core/PaymentAdapterInterface.php
+++ b/src/SwedbankPay/Core/PaymentAdapterInterface.php
@@ -186,4 +186,23 @@ interface PaymentAdapterInterface
         $expiryDate,
         $orderId = null
     );
+
+    /**
+     * Process payment object.
+     *
+     * @param mixed $paymentObject
+     * @param mixed $orderId
+     *
+     * @return mixed
+     */
+    public function processPaymentObject($paymentObject, $orderId);
+
+    /**
+     * Generate Payee Reference for Order.
+     *
+     * @param mixed $orderId
+     *
+     * @return string
+     */
+    public function generatePayeeReference($orderId);
 }

--- a/tests/Adapter.php
+++ b/tests/Adapter.php
@@ -294,55 +294,83 @@ class Adapter extends PaymentAdapter implements PaymentAdapterInterface
         // @todo
     }
 
-	/**
-	 * Get Order Status.
-	 *
-	 * @param $orderId
-	 *
-	 * @return string
-	 * @throws Exception
-	 *@see wc_get_order_statuses()
-	 */
-	public function getOrderStatus($orderId)
-	{
-		return OrderInterface::STATUS_AUTHORIZED;
-	}
+    /**
+     * Get Order Status.
+     *
+     * @param $orderId
+     *
+     * @return string
+     * @throws Exception
+     *@see wc_get_order_statuses()
+     */
+    public function getOrderStatus($orderId)
+    {
+        return OrderInterface::STATUS_AUTHORIZED;
+    }
 
-	/**
-	 * Set Payment Id to Order.
-	 *
-	 * @param mixed $orderId
-	 * @param string $paymentId
-	 *
-	 * @return void
-	 */
-	public function setPaymentId($orderId, $paymentId)
-	{
-		// @todo
-	}
+    /**
+     * Set Payment Id to Order.
+     *
+     * @param mixed $orderId
+     * @param string $paymentId
+     *
+     * @return void
+     */
+    public function setPaymentId($orderId, $paymentId)
+    {
+        // @todo
+    }
 
-	/**
-	 * Set Payment Order Id to Order.
-	 *
-	 * @param mixed $orderId
-	 * @param string $paymentOrderId
-	 *
-	 * @return void
-	 */
-	public function setPaymentOrderId($orderId, $paymentOrderId)
-	{
-		// @todo
-	}
+    /**
+     * Set Payment Order Id to Order.
+     *
+     * @param mixed $orderId
+     * @param string $paymentOrderId
+     *
+     * @return void
+     */
+    public function setPaymentOrderId($orderId, $paymentOrderId)
+    {
+        // @todo
+    }
 
-	/**
-	 * Get Payment Method.
-	 *
-	 * @param mixed $orderId
-	 *
-	 * @return string|null Returns method or null if not exists
-	 */
-	public function getPaymentMethod($orderId)
-	{
-		return PaymentAdapterInterface::METHOD_CC;
-	}
+    /**
+     * Get Payment Method.
+     *
+     * @param mixed $orderId
+     *
+     * @return string|null Returns method or null if not exists
+     */
+    public function getPaymentMethod($orderId)
+    {
+        return PaymentAdapterInterface::METHOD_CC;
+    }
+
+    /**
+     * Process payment object.
+     *
+     * @param mixed $paymentObject
+     * @param mixed $orderId
+     *
+     * @return mixed
+     */
+    public function processPaymentObject($paymentObject, $orderId)
+    {
+        return $paymentObject;
+    }
+
+    /**
+     * Generate Payee Reference for Order.
+     *
+     * @param mixed $orderId
+     *
+     * @return string
+     */
+    public function generatePayeeReference($orderId)
+    {
+        $arr = range('a', 'z');
+        shuffle($arr);
+
+        return $orderId . 'x' . substr(implode('', $arr), 0, 5);
+    }
 }

--- a/tests/unit/CheckoutTest.php
+++ b/tests/unit/CheckoutTest.php
@@ -9,13 +9,13 @@ class CheckoutTest extends TestCase
         // Test initialization
         $result = $this->core->initiatePaymentOrderPurchase(1, null);
         $this->assertInstanceOf(Response::class, $result);
-        $this->assertArrayHasKey('paymentOrder', $result);
+        /* $this->assertArrayHasKey('paymentOrder', $result);
         $this->assertArrayHasKey('operations', $result);
         $this->assertIsArray($result['paymentOrder']);
         $this->assertArrayHasKey('id', $result['paymentOrder']);
         $this->assertArrayHasKey('operation', $result['paymentOrder']);
         $this->assertArrayHasKey('state', $result['paymentOrder']);
-        $this->assertArrayHasKey('items', $result['paymentOrder']);
+        $this->assertArrayHasKey('items', $result['paymentOrder']); */
         $this->assertIsString($result->getOperationByRel('update-paymentorder-updateorder'));
         $this->assertIsString($result->getOperationByRel('update-paymentorder-abort'));
         $this->assertIsString($result->getOperationByRel('redirect-paymentorder'));

--- a/tests/unit/CheckoutTest.php
+++ b/tests/unit/CheckoutTest.php
@@ -9,13 +9,13 @@ class CheckoutTest extends TestCase
         // Test initialization
         $result = $this->core->initiatePaymentOrderPurchase(1, null);
         $this->assertInstanceOf(Response::class, $result);
-        /* $this->assertArrayHasKey('paymentOrder', $result);
+        $this->assertArrayHasKey('payment_order', $result);
         $this->assertArrayHasKey('operations', $result);
-        $this->assertIsArray($result['paymentOrder']);
-        $this->assertArrayHasKey('id', $result['paymentOrder']);
-        $this->assertArrayHasKey('operation', $result['paymentOrder']);
-        $this->assertArrayHasKey('state', $result['paymentOrder']);
-        $this->assertArrayHasKey('items', $result['paymentOrder']); */
+        $this->assertIsArray($result['payment_order']);
+        $this->assertArrayHasKey('id', $result['payment_order']);
+        $this->assertArrayHasKey('operation', $result['payment_order']);
+        $this->assertArrayHasKey('state', $result['payment_order']);
+        $this->assertArrayHasKey('items', $result['payment_order']);
         $this->assertIsString($result->getOperationByRel('update-paymentorder-updateorder'));
         $this->assertIsString($result->getOperationByRel('update-paymentorder-abort'));
         $this->assertIsString($result->getOperationByRel('redirect-paymentorder'));
@@ -47,7 +47,7 @@ class CheckoutTest extends TestCase
      */
     public function testGetPaymentIdByPaymentOrder(Response $response)
     {
-        $paymentId = $this->core->getPaymentIdByPaymentOrder($response['paymentOrder']['id']);
+        $paymentId = $this->core->getPaymentIdByPaymentOrder($response['payment_order']['id']);
         $this->assertEquals(false, $paymentId);
     }
 
@@ -67,6 +67,7 @@ class CheckoutTest extends TestCase
                 ]
             ]
         );
+
         $this->assertInstanceOf(Response::class, $result);
         $this->assertArrayHasKey('state', $result['paymentOrder']);
         $this->assertEquals('Aborted', $result['paymentOrder']['state']);


### PR DESCRIPTION
* Added methods:
`processPaymentObject()`
`generatePayeeReference()`

* WordPress filters:
`swedbank_pay_order_reference`
`swedbank_pay_payee_name`
`swedbank_pay_autocapture`
`swedbank_pay_subsite`
`swedbank_pay_language`

* Allow to use classes from `swedbank-pay-sdk-php` for CreditCard and Checkout

Fixes https://github.com/SwedbankPay/swedbank-pay-woocommerce-core/issues/40