### PR TITLE
Fixed: Uncaught Error: Call to a member function getReference() on array

### DIFF
--- a/src/SwedbankPay/Core/Library/Methods/Checkout.php
+++ b/src/SwedbankPay/Core/Library/Methods/Checkout.php
@@ -481,6 +481,7 @@ trait Checkout
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @SuppressWarnings(PHPMD.MissingImport)
      */
     public function captureCheckout($orderId, $amount = null, $vatAmount = 0, array $items = [])
     {
@@ -705,6 +706,7 @@ trait Checkout
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ElseExpression)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @SuppressWarnings(PHPMD.MissingImport)
      */
     public function refundCheckout($orderId, $amount = null, $vatAmount = 0, array $items = [])
     {

--- a/src/SwedbankPay/Core/Library/Methods/Checkout.php
+++ b/src/SwedbankPay/Core/Library/Methods/Checkout.php
@@ -500,7 +500,9 @@ trait Checkout
         // Build items collection
         $orderItems = new OrderItemsCollection();
         foreach ($items as $item) {
-            /** @var OrderItemInterface $item */
+            if (is_array($item)) {
+                $item = new \SwedbankPay\Core\OrderItem($item);
+            }
 
             $orderItem = new OrderItem();
             $orderItem
@@ -725,10 +727,12 @@ trait Checkout
         $amount = 0;
         $vatAmount = 0;
         foreach ($items as $item) {
+            if (is_array($item)) {
+                $item = new \SwedbankPay\Core\OrderItem($item);
+            }
+
             $amount += $item->getAmount();
             $vatAmount += $item->getVatAmount();
-
-            /** @var OrderItemInterface $item */
 
             $orderItem = new OrderItem();
             $orderItem


### PR DESCRIPTION
Fixes error:
Uncaught Error: Call to a member function getReference() on array in /var/www/html/wp-content/plugins/swedbank-pay-checkout/vendor/swedbank-pay/swedbank-pay-woocommerce-core/src/SwedbankPay/Core/Library/Methods/Checkout.php:507