### PR TITLE
Implemented Adapter::processTransactionObject() method

### DIFF
--- a/src/SwedbankPay/Core/Adapter/WC_Adapter.php
+++ b/src/SwedbankPay/Core/Adapter/WC_Adapter.php
@@ -1049,6 +1049,19 @@ class WC_Adapter extends PaymentAdapter implements PaymentAdapterInterface
     }
 
     /**
+     * Process transaction object.
+     *
+     * @param mixed $transactionObject
+     * @param mixed $orderId
+     *
+     * @return mixed
+     */
+    public function processTransactionObject($transactionObject, $orderId)
+    {
+        return apply_filters('swedbank_pay_transaction_object', $transactionObject, $orderId);
+    }
+
+    /**
      * Generate Payee Reference for Order.
      *
      * @param mixed $orderId

--- a/src/SwedbankPay/Core/Library/Methods/Checkout.php
+++ b/src/SwedbankPay/Core/Library/Methods/Checkout.php
@@ -537,6 +537,9 @@ trait Checkout
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
 
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
+
         $requestService = new TransactionCapture($transaction);
         $requestService->setClient($this->client)
                        ->setPaymentOrderId($paymentOrderId);
@@ -616,6 +619,9 @@ trait Checkout
 
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
+
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
 
         $requestService = new TransactionCancel($transaction);
         $requestService->setClient($this->client)
@@ -737,6 +743,9 @@ trait Checkout
 
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
+
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
 
         $requestService = new TransactionReversal($transaction);
         $requestService->setClient($this->client)

--- a/src/SwedbankPay/Core/Library/Methods/Invoice.php
+++ b/src/SwedbankPay/Core/Library/Methods/Invoice.php
@@ -323,6 +323,9 @@ trait Invoice
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
 
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
+
         $requestService = new CreateCapture($transaction);
         $requestService->setClient($this->client);
         $requestService->setPaymentId($paymentId);
@@ -425,6 +428,9 @@ trait Invoice
 
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
+
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
 
         $requestService = new CreateCancellation($transaction);
         $requestService
@@ -535,6 +541,9 @@ trait Invoice
 
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
+
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
 
         $requestService = new CreateReversal($transaction);
         $requestService

--- a/src/SwedbankPay/Core/Library/OrderAction.php
+++ b/src/SwedbankPay/Core/Library/OrderAction.php
@@ -210,6 +210,9 @@ trait OrderAction
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
 
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
+
         $requestService = new CreateCapture($transaction);
         $requestService->setClient($this->client);
         $requestService->setPaymentId($paymentId);
@@ -299,6 +302,9 @@ trait OrderAction
 
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
+
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
 
         $requestService = new CreateCancellation($transaction);
         $requestService->setClient($this->client);
@@ -393,6 +399,9 @@ trait OrderAction
 
         $transaction = new TransactionObject();
         $transaction->setTransaction($transactionData);
+
+        // Process transaction object
+        $transaction = $this->adapter->processTransactionObject($transaction, $orderId);
 
         $requestService = new CreateReversal($transaction);
         $requestService->setClient($this->client);

--- a/src/SwedbankPay/Core/PaymentAdapterInterface.php
+++ b/src/SwedbankPay/Core/PaymentAdapterInterface.php
@@ -198,6 +198,16 @@ interface PaymentAdapterInterface
     public function processPaymentObject($paymentObject, $orderId);
 
     /**
+     * Process transaction object.
+     *
+     * @param mixed $transactionObject
+     * @param mixed $orderId
+     *
+     * @return mixed
+     */
+    public function processTransactionObject($transactionObject, $orderId);
+
+    /**
      * Generate Payee Reference for Order.
      *
      * @param mixed $orderId

--- a/tests/Adapter.php
+++ b/tests/Adapter.php
@@ -361,6 +361,19 @@ class Adapter extends PaymentAdapter implements PaymentAdapterInterface
     }
 
     /**
+     * Process transaction object.
+     *
+     * @param mixed $transactionObject
+     * @param mixed $orderId
+     *
+     * @return mixed
+     */
+    public function processTransactionObject($transactionObject, $orderId)
+    {
+        return $transactionObject;
+    }
+
+    /**
      * Generate Payee Reference for Order.
      *
      * @param mixed $orderId

--- a/tests/unit/AdapterTest.php
+++ b/tests/unit/AdapterTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use SwedbankPay\Api\Service\Creditcard\Resource\Request\PaymentPurchaseObject;
+use SwedbankPay\Api\Service\Payment\Transaction\Resource\Request\TransactionObject;
+
+class AdapterTest extends TestCase
+{
+    public function testAdapter()
+    {
+        $paymentObject = new PaymentPurchaseObject();
+        $result = $this->adapter->processPaymentObject($paymentObject, 123);
+        $this->assertInstanceOf(PaymentPurchaseObject::class, $result);
+
+        $transaction = new TransactionObject();
+        $result = $this->adapter->processTransactionObject($transaction, 123);
+        $this->assertInstanceOf(TransactionObject::class, $result);
+    }
+}


### PR DESCRIPTION
Implemented `Adapter::processTransactionObject()` method to handle capture/cancel/refund actions.
WooCommerce adapter uses `swedbank_pay_transaction_object` wp filter.


