### PR TITLE
Remove the workaround

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 5.2.1
+Changed
+- Removed the workaround in WC_Adapter
+
 Version 5.2.0
 Added
 - Added method `isCreditMemoExist($transactionId)`

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
       "email": "asbjorn.ulsberg@payex.com"
     }
   ],
-  "version": "5.2.0",
+  "version": "5.2.1",
   "keywords": [
     "SwedbankPay",
     "core",

--- a/src/SwedbankPay/Core/Adapter/WC_Adapter.php
+++ b/src/SwedbankPay/Core/Adapter/WC_Adapter.php
@@ -190,11 +190,6 @@ class WC_Adapter extends PaymentAdapter implements PaymentAdapterInterface
             $paymentUrl = add_query_arg(array('payment_url' => '1'), wc_get_checkout_url());
         }
 
-        // Workaround: don't set paymentUrl if there's "pay_for_order" page
-        if (isset($_GET['pay_for_order'], $_GET['key'])) {
-            $paymentUrl = null;
-        }
-
         if ($this->gateway->is_new_credit_card) {
             return array(
                 PlatformUrlsInterface::COMPLETE_URL => add_query_arg(

--- a/src/SwedbankPay/Core/Library/Methods/Checkout.php
+++ b/src/SwedbankPay/Core/Library/Methods/Checkout.php
@@ -37,7 +37,7 @@ trait Checkout
      *
      * @param mixed $orderId
      * @param string|null $consumerProfileRef
-     * @param bool $generateRecurrenceToken
+     * @param bool $generateToken
      *
      * @return Response
      * @throws Exception
@@ -48,7 +48,7 @@ trait Checkout
     public function initiatePaymentOrderPurchase(
         $orderId,
         $consumerProfileRef = null,
-        $generateRecurrenceToken = false
+        $generateToken = false
     ) {
         /** @var Order $order */
         $order = $this->getOrder($orderId);
@@ -118,7 +118,7 @@ trait Checkout
             ->setDescription($order->getDescription())
             ->setUserAgent($order->getHttpUserAgent())
             ->setLanguage($order->getLanguage())
-            ->setGenerateRecurrenceToken($generateRecurrenceToken)
+            ->setGenerateRecurrenceToken($generateToken)
             ->setDisablePaymentMenu(false)
             ->setUrls($urlData)
             ->setPayeeInfo($payeeInfo)


### PR DESCRIPTION
Remove workaround:
```php
// Workaround: don't set paymentUrl if there's "pay_for_order" page
        if (isset($_GET['pay_for_order'], $_GET['key'])) {
            $paymentUrl = null;
        }
```
